### PR TITLE
fix(ci): use claude_code_oauth_token input for Claude Code Action

### DIFF
--- a/.github/workflows/ci-failure-auto-fix.yml
+++ b/.github/workflows/ci-failure-auto-fix.yml
@@ -93,5 +93,5 @@ jobs:
 
             Error logs:
             ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)'"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -58,6 +58,6 @@ jobs:
 
             Be thorough but efficient. Focus on finding true duplicates, not just similar issues.
 
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -23,6 +24,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: "*"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-code-analysis.yml
+++ b/.github/workflows/manual-code-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Claude Analysis
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -20,7 +20,7 @@ jobs:
       - name: PR Review with Progress Tracking
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Fix authentication failure in all Claude Code Action workflows
- The action has a dedicated `claude_code_oauth_token` input separate from `anthropic_api_key` — using the wrong input caused immediate exit (code 1, 0 API calls, 151ms)
- Add missing `id-token: write` permission to `issue-triage.yml`

## Changes
All 6 workflows updated: `anthropic_api_key` → `claude_code_oauth_token`

## Root cause
The `action.yml` defines both inputs:
```yaml
anthropic_api_key:
  description: "Anthropic API key (required for direct API, not needed for Bedrock/Vertex/Foundry)"
claude_code_oauth_token:
  description: "Claude Code OAuth token (alternative to anthropic_api_key)"
```
Passing an OAuth token (`sk-ant-oat01-*`) to `anthropic_api_key` causes the SDK to fail immediately.