### PR TITLE
fix(ci): harden pr-review-comprehensive workflow

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -1,12 +1,19 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 name: PR Review with Progress Tracking
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review-with-tracking:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- add workflow schema header to `.github/workflows/pr-review-comprehensive.yml`
- add `concurrency` to avoid duplicate review jobs per PR
- add `timeout-minutes: 30` to prevent hung runs

## Scope
- only `.github/workflows/pr-review-comprehensive.yml` is changed

## Why urgent
This workflow must be aligned with `main` immediately so other PR branches can sync to it.
