### PR TITLE
chore(ci): pin selected Claude workflows to exact Opus model id

### DIFF
--- a/.github/workflows/ci-failure-auto-fix.yml
+++ b/.github/workflows/ci-failure-auto-fix.yml
@@ -101,4 +101,6 @@ jobs:
             Error logs:
             ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)'"
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,3 +42,5 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-5-20251101

--- a/.github/workflows/manual-code-analysis.yml
+++ b/.github/workflows/manual-code-analysis.yml
@@ -38,6 +38,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-5-20251101
           prompt: |
             REPO: ${{ github.repository }}
             BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -64,4 +64,5 @@ jobs:
             Use top-level comments for general observations or praise.
 
           claude_args: |
+            --model claude-opus-4-5-20251101
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- pin Claude Code Action workflows to an exact Opus model ID: `claude-opus-4-5-20251101`
- apply only to selected workflows
- intentionally skip:
  - `.github/workflows/issue-deduplication.yml`
  - `.github/workflows/issue-triage.yml`

## Files changed
- `.github/workflows/ci-failure-auto-fix.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/manual-code-analysis.yml`
- `.github/workflows/pr-review-comprehensive.yml`

## Source for model ID
From Anthropic docs:
- https://docs.anthropic.com/en/docs/claude-code/model-config
- https://docs.anthropic.com/en/docs/about-claude/models/overview

The model-config doc states aliases point to latest and shows a pinned full model example `claude-opus-4-5-20251101`, which is used here for deterministic behavior.

## Validation
- `nix run nixpkgs#actionlint -- .github/workflows/*.yml`
- `for f in .github/workflows/*.yml; do nix run nixpkgs#yq-go -- eval '.' "$f" >/dev/null; done`
- `nix develop .#hooks -c lefthook run pre-commit --all-files`
