### PR TITLE
fix(release): correct gh release target commitish usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,8 +446,6 @@ jobs:
 
           release_args=(
             "${RELEASE_TAG}"
-            "--target"
-            "${RELEASE_TAG}"
             "--title"
             "${RELEASE_TAG}"
             "--notes-file"


### PR DESCRIPTION
## Summary
- remove `--target ${RELEASE_TAG}` from `gh release create`
- keep release tag creation in the previous step (`git tag` + `git push`) and let `gh release create` publish from that tag

## Why
`gh release create --target` expects a branch or commit SHA. Passing the tag name produced:
`Release.target_commitish is invalid`.
