### PR TITLE
fix(ci): render wrangler bindings from environment vars

### DIFF
--- a/.github/workflows/r2-explorer-deploy.yml
+++ b/.github/workflows/r2-explorer-deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "r2-explorer/**"
       - ".github/workflows/r2-explorer-deploy.yml"
+      - "scripts/ci/render-r2-explorer-wrangler-config.sh"
       - "scripts/ci/worker-share-smoke.sh"
   workflow_dispatch:
     inputs:
@@ -33,11 +34,20 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      R2E_FILES_BUCKET: ${{ vars.R2E_FILES_BUCKET }}
+      R2E_FILES_BUCKET_PREVIEW: ${{ vars.R2E_FILES_BUCKET_PREVIEW }}
+      R2E_SHARES_KV_ID: ${{ vars.R2E_SHARES_KV_ID }}
+      R2E_SHARES_KV_ID_PREVIEW: ${{ vars.R2E_SHARES_KV_ID_PREVIEW }}
+      R2E_KEYS_KV_ID: ${{ vars.R2E_KEYS_KV_ID }}
+      R2E_KEYS_KV_ID_PREVIEW: ${{ vars.R2E_KEYS_KV_ID_PREVIEW }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Render Wrangler config
+        run: ./scripts/ci/render-r2-explorer-wrangler-config.sh r2-explorer/wrangler.ci.toml
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -65,7 +75,7 @@ jobs:
 
       - name: Deploy preview
         working-directory: r2-explorer
-        run: pnpm run deploy -- --env preview
+        run: pnpm run deploy -- --config wrangler.ci.toml --env preview
 
   smoke-preview:
     name: Smoke preview
@@ -179,9 +189,10 @@ jobs:
             echo '```bash'
             echo 'git fetch origin'
             echo "git checkout ${rollback_sha}"
+            echo './scripts/ci/render-r2-explorer-wrangler-config.sh r2-explorer/wrangler.ci.toml'
             echo 'cd r2-explorer'
             echo 'pnpm install --frozen-lockfile'
-            echo 'pnpm run deploy -- --env preview'
+            echo 'pnpm run deploy -- --config wrangler.ci.toml --env preview'
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -196,6 +207,12 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      R2E_FILES_BUCKET: ${{ vars.R2E_FILES_BUCKET }}
+      R2E_FILES_BUCKET_PREVIEW: ${{ vars.R2E_FILES_BUCKET_PREVIEW }}
+      R2E_SHARES_KV_ID: ${{ vars.R2E_SHARES_KV_ID }}
+      R2E_SHARES_KV_ID_PREVIEW: ${{ vars.R2E_SHARES_KV_ID_PREVIEW }}
+      R2E_KEYS_KV_ID: ${{ vars.R2E_KEYS_KV_ID }}
+      R2E_KEYS_KV_ID_PREVIEW: ${{ vars.R2E_KEYS_KV_ID_PREVIEW }}
     steps:
       - name: Reject non-main production deploy ref
         run: |
@@ -209,6 +226,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
+
+      - name: Render Wrangler config
+        run: ./scripts/ci/render-r2-explorer-wrangler-config.sh r2-explorer/wrangler.ci.toml
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -236,7 +256,7 @@ jobs:
 
       - name: Deploy production
         working-directory: r2-explorer
-        run: pnpm run deploy
+        run: pnpm run deploy -- --config wrangler.ci.toml
 
   smoke-production:
     name: Smoke production
@@ -343,8 +363,9 @@ jobs:
             echo '```bash'
             echo 'git fetch origin'
             echo "git checkout ${rollback_sha}"
+            echo './scripts/ci/render-r2-explorer-wrangler-config.sh r2-explorer/wrangler.ci.toml'
             echo 'cd r2-explorer'
             echo 'pnpm install --frozen-lockfile'
-            echo 'pnpm run deploy'
+            echo 'pnpm run deploy -- --config wrangler.ci.toml'
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/operators/rollback-worker-share.md
+++ b/docs/operators/rollback-worker-share.md
@@ -24,7 +24,10 @@ regression.
 - Last known-good values for:
   - `R2E_READONLY`
   - keyset/secret references for admin auth
-  - bound KV namespace configuration
+  - bound KV namespace and bucket configuration (`R2E_FILES_BUCKET`,
+    `R2E_FILES_BUCKET_PREVIEW`, `R2E_SHARES_KV_ID`,
+    `R2E_SHARES_KV_ID_PREVIEW`, `R2E_KEYS_KV_ID`,
+    `R2E_KEYS_KV_ID_PREVIEW`)
 - Target domain for verification (`https://files.example.com`)
 
 ## Procedure (CLI-first)
@@ -39,8 +42,9 @@ regression.
 5. Deploy rollback revision:
 
 ```bash
+./scripts/ci/render-r2-explorer-wrangler-config.sh r2-explorer/wrangler.ci.toml
 cd r2-explorer
-wrangler deploy
+wrangler deploy --config wrangler.ci.toml
 ```
 
 6. Validate lifecycle and route behavior:

--- a/r2-explorer/README.md
+++ b/r2-explorer/README.md
@@ -101,6 +101,15 @@ Required environment secrets in both environments:
 - `R2E_SMOKE_BUCKET`
 - `R2E_SMOKE_KEY`
 
+Required environment variables in both environments (non-secret binding IDs/names):
+
+- `R2E_FILES_BUCKET`
+- `R2E_FILES_BUCKET_PREVIEW`
+- `R2E_SHARES_KV_ID`
+- `R2E_SHARES_KV_ID_PREVIEW`
+- `R2E_KEYS_KV_ID`
+- `R2E_KEYS_KV_ID_PREVIEW`
+
 Optional smoke tuning environment variables:
 
 - `R2E_SMOKE_TIMEOUT` (seconds, default `60`)

--- a/scripts/ci/render-r2-explorer-wrangler-config.sh
+++ b/scripts/ci/render-r2-explorer-wrangler-config.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [[ -z ${!name:-} ]]; then
+    echo "Error: required environment variable is missing: ${name}" >&2
+    exit 1
+  fi
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+main() {
+  local output_path template_path
+  output_path="${1:-r2-explorer/wrangler.ci.toml}"
+  template_path="${2:-r2-explorer/wrangler.toml}"
+
+  require_env "R2E_FILES_BUCKET"
+  require_env "R2E_FILES_BUCKET_PREVIEW"
+  require_env "R2E_SHARES_KV_ID"
+  require_env "R2E_SHARES_KV_ID_PREVIEW"
+  require_env "R2E_KEYS_KV_ID"
+  require_env "R2E_KEYS_KV_ID_PREVIEW"
+
+  sed \
+    -e "s|replace-with-r2-bucket-preview|$(escape_sed_replacement "${R2E_FILES_BUCKET_PREVIEW}")|g" \
+    -e "s|replace-with-r2-bucket|$(escape_sed_replacement "${R2E_FILES_BUCKET}")|g" \
+    -e "s|replace-with-shares-kv-namespace-id-preview|$(escape_sed_replacement "${R2E_SHARES_KV_ID_PREVIEW}")|g" \
+    -e "s|replace-with-shares-kv-namespace-id|$(escape_sed_replacement "${R2E_SHARES_KV_ID}")|g" \
+    -e "s|replace-with-keys-kv-namespace-id-preview|$(escape_sed_replacement "${R2E_KEYS_KV_ID_PREVIEW}")|g" \
+    -e "s|replace-with-keys-kv-namespace-id|$(escape_sed_replacement "${R2E_KEYS_KV_ID}")|g" \
+    "${template_path}" >"${output_path}"
+
+  if grep -q "replace-with-" "${output_path}"; then
+    echo "Error: unresolved placeholder remains in ${output_path}" >&2
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- keep `r2-explorer/wrangler.toml` placeholder-only in git
- add `scripts/ci/render-r2-explorer-wrangler-config.sh` to render a runtime config from GitHub environment variables
- update deploy workflow to render and deploy with `--config wrangler.ci.toml`
- document required environment variables and rollback deploy command changes

## Why
The previous deploy failure came from placeholder KV/R2 bindings in tracked config. This change avoids committing concrete IDs/names while still providing valid bindings at deploy time from GitHub environment variables.
