### PR TITLE
fix(r2-sync): expire orphaned bisync locks with --max-lock

### DIFF
--- a/docs/reference/services-r2-sync.md
+++ b/docs/reference/services-r2-sync.md
@@ -9,24 +9,25 @@ Credentials are expected in `/run/secrets/r2/credentials.env` (rendered from
 
 ## Options
 
-| Option                                                    | Type                                                         | Default       | Required when enabled                 | Notes                                                         |
-| --------------------------------------------------------- | ------------------------------------------------------------ | ------------- | ------------------------------------- | ------------------------------------------------------------- |
-| `services.r2-sync.enable`                                 | boolean                                                      | `false`       | no                                    | Enables service and timer generation.                         |
-| `services.r2-sync.credentialsFile`                        | `null` or path                                               | `null`        | yes                                   | Environment file loaded by systemd units.                     |
-| `services.r2-sync.accountId`                              | string                                                       | `""`          | yes (if file unset)                   | Used to build `https://<accountId>.r2.cloudflarestorage.com`. |
-| `services.r2-sync.accountIdFile`                          | `null` or path                                               | `null`        | yes (if literal unset)                | File-based account ID source.                                 |
-| `services.r2-sync.mounts`                                 | attrset of submodules                                        | `{}`          | yes (must contain at least one mount) | One mount profile per attr key.                               |
-| `services.r2-sync.mounts.<name>.bucket`                   | string                                                       | none          | yes                                   | Remote bucket name; must be non-empty.                        |
-| `services.r2-sync.mounts.<name>.remotePrefix`             | string                                                       | `""`          | yes                                   | Remote subpath inside the bucket (mount/sync root).           |
-| `services.r2-sync.mounts.<name>.mountPoint`               | path                                                         | none          | yes                                   | Local mount location for `rclone mount`.                      |
-| `services.r2-sync.mounts.<name>.localPath`                | `null` or path                                               | `null`        | no                                    | Local bisync side; falls back to `mountPoint`.                |
-| `services.r2-sync.mounts.<name>.syncInterval`             | string                                                       | `"5m"`        | no                                    | `OnUnitActiveSec` value for bisync timer.                     |
-| `services.r2-sync.mounts.<name>.bisync.maxDelete`         | integer                                                      | `100000`      | no                                    | Passed to `rclone bisync --max-delete`.                       |
-| `services.r2-sync.mounts.<name>.bisync.checkFilename`     | string                                                       | `".r2-check"` | no                                    | Used for `--check-access` safety.                             |
-| `services.r2-sync.mounts.<name>.bisync.initialResyncMode` | enum `path1`, `path2`, `newer`, `older`, `larger`, `smaller` | `"path1"`     | no                                    | Used on first run to seed bisync state.                       |
-| `services.r2-sync.mounts.<name>.vfsCache.mode`            | enum `off`, `minimal`, `writes`, `full`                      | `"full"`      | no                                    | Passed to `--vfs-cache-mode`.                                 |
-| `services.r2-sync.mounts.<name>.vfsCache.maxSize`         | string                                                       | `"10G"`       | no                                    | Passed to `--vfs-cache-max-size`.                             |
-| `services.r2-sync.mounts.<name>.vfsCache.maxAge`          | string                                                       | `"24h"`       | no                                    | Passed to `--vfs-cache-max-age`.                              |
+| Option                                                    | Type                                                         | Default       | Required when enabled                 | Notes                                                                      |
+| --------------------------------------------------------- | ------------------------------------------------------------ | ------------- | ------------------------------------- | -------------------------------------------------------------------------- |
+| `services.r2-sync.enable`                                 | boolean                                                      | `false`       | no                                    | Enables service and timer generation.                                      |
+| `services.r2-sync.credentialsFile`                        | `null` or path                                               | `null`        | yes                                   | Environment file loaded by systemd units.                                  |
+| `services.r2-sync.accountId`                              | string                                                       | `""`          | yes (if file unset)                   | Used to build `https://<accountId>.r2.cloudflarestorage.com`.              |
+| `services.r2-sync.accountIdFile`                          | `null` or path                                               | `null`        | yes (if literal unset)                | File-based account ID source.                                              |
+| `services.r2-sync.mounts`                                 | attrset of submodules                                        | `{}`          | yes (must contain at least one mount) | One mount profile per attr key.                                            |
+| `services.r2-sync.mounts.<name>.bucket`                   | string                                                       | none          | yes                                   | Remote bucket name; must be non-empty.                                     |
+| `services.r2-sync.mounts.<name>.remotePrefix`             | string                                                       | `""`          | yes                                   | Remote subpath inside the bucket (mount/sync root).                        |
+| `services.r2-sync.mounts.<name>.mountPoint`               | path                                                         | none          | yes                                   | Local mount location for `rclone mount`.                                   |
+| `services.r2-sync.mounts.<name>.localPath`                | `null` or path                                               | `null`        | no                                    | Local bisync side; falls back to `mountPoint`.                             |
+| `services.r2-sync.mounts.<name>.syncInterval`             | string                                                       | `"5m"`        | no                                    | `OnUnitActiveSec` value for bisync timer.                                  |
+| `services.r2-sync.mounts.<name>.bisync.maxDelete`         | integer                                                      | `100000`      | no                                    | Passed to `rclone bisync --max-delete`.                                    |
+| `services.r2-sync.mounts.<name>.bisync.checkFilename`     | string                                                       | `".r2-check"` | no                                    | Used for `--check-access` safety.                                          |
+| `services.r2-sync.mounts.<name>.bisync.initialResyncMode` | enum `path1`, `path2`, `newer`, `older`, `larger`, `smaller` | `"path1"`     | no                                    | Used on first run to seed bisync state.                                    |
+| `services.r2-sync.mounts.<name>.bisync.maxLock`           | string                                                       | `"15m"`       | no                                    | Passed to `rclone bisync --max-lock`; `""` omits it so locks never expire. |
+| `services.r2-sync.mounts.<name>.vfsCache.mode`            | enum `off`, `minimal`, `writes`, `full`                      | `"full"`      | no                                    | Passed to `--vfs-cache-mode`.                                              |
+| `services.r2-sync.mounts.<name>.vfsCache.maxSize`         | string                                                       | `"10G"`       | no                                    | Passed to `--vfs-cache-max-size`.                                          |
+| `services.r2-sync.mounts.<name>.vfsCache.maxAge`          | string                                                       | `"24h"`       | no                                    | Passed to `--vfs-cache-max-age`.                                           |
 
 ## Mount vs Bisync (How to Use the Two Paths)
 
@@ -75,6 +76,14 @@ When `enable = true`, evaluation fails if any assertion below is violated:
 - If prior listing cache exists but no longer matches the current local/remote
   basename pair (for example, path case changes), the wrapper retries once with
   `--resync --resync-mode <initialResyncMode>` automatically.
+- Bisync passes `--max-lock` (default `15m`) so a run orphaned by a crash or
+  shutdown self-expires and the next run can take over; rclone renews the lock
+  while a run is alive and clamps values under 2m up to 2m. Interrupted runs
+  self-heal via `--recover`/`--resilient` rather than needing a manual
+  `--resync`. As a fast-path the wrapper also clears a `.lck` whose recorded
+  holder PID is no longer running and retries once. Setting `maxLock = ""` omits
+  `--max-lock` and disables that cleanup, restoring rclone's native behavior
+  where an orphaned lock blocks every later run until removed by hand.
 
 ## Generated runtime artifacts
 

--- a/flake.nix
+++ b/flake.nix
@@ -282,7 +282,18 @@
               if failed != [ ] then
                 throw "nixos-module-eval check failed assertions: ${failedMessages}"
               else
-                pkgs.writeText "r2-nixos-module-eval" forced;
+                builtins.seq forced (
+                  pkgs.runCommand "r2-nixos-module-eval" { } ''
+                    # Regression guard for the bisync lock-expiry fix: rclone only
+                    # expires a lock orphaned by a crash or shutdown when run with
+                    # --max-lock, so require it in the generated bisync unit.
+                    if ! grep -q -- '--max-lock' ${units."r2-bisync-documents".serviceConfig.ExecStart}; then
+                      echo "r2-bisync ExecStart is missing --max-lock; an orphaned lock would wedge the service permanently" >&2
+                      exit 1
+                    fi
+                    touch "$out"
+                  ''
+                );
           };
 
           devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -287,7 +287,7 @@
                     # Regression guard for the bisync lock-expiry fix: rclone only
                     # expires a lock orphaned by a crash or shutdown when run with
                     # --max-lock, so require it in the generated bisync unit.
-                    if ! grep -q -- '--max-lock' ${units."r2-bisync-documents".serviceConfig.ExecStart}; then
+                    if ! grep -q -- '--max-lock=' ${units."r2-bisync-documents".serviceConfig.ExecStart}; then
                       echo "r2-bisync ExecStart is missing --max-lock; an orphaned lock would wedge the service permanently" >&2
                       exit 1
                     fi

--- a/modules/nixos/r2-sync.nix
+++ b/modules/nixos/r2-sync.nix
@@ -194,22 +194,27 @@ let
 
         printf '%s\n' "$bisync_output" >&2
 
-        # A lock file left by a run that was killed (host shutdown, OOM, crash)
-        # blocks every later run with "prior lock file found". The bisync workdir
-        # is host-local and single-writer, so a lock whose recorded holder PID is
-        # no longer running is a safe orphan to clear, then retry once. --max-lock
-        # auto-expires orphans written after it was set; this branch also recovers
-        # locks written before it, whose stored expiry is far in the future.
-        if [[ "$bisync_output" == *"prior lock file found"* ]]; then
+        # A crash or shutdown can orphan a .lck that then blocks every later run
+        # with "prior lock file found". The workdir is host-local and
+        # single-writer, so clearing a lock whose holder PID is dead and retrying
+        # once is safe. Gated on --max-lock: with maxLock = "" the user opts into
+        # rclone's native never-expire locks, which must be cleared by hand.
+        if [[ -n "${maxLockArg}" ]] \
+          && [[ "$bisync_output" == *"prior lock file found"* ]]; then
           cleared_lock=false
+          # rclone writes .lck as compact JSON with a quoted string PID
+          # ("PID":"12345"); tolerate whitespace and unquoted ints against drift.
+          pid_regex='"PID"[[:space:]]*:[[:space:]]*"?([0-9]+)"?'
           for lock_file in ${workdirArg}/*.lck; do
             [[ -f "$lock_file" ]] || continue
             lock_pid=""
             lock_content="$(< "$lock_file")" || true
-            if [[ "$lock_content" =~ \"PID\":\"([0-9]+)\" ]]; then
+            if [[ "$lock_content" =~ $pid_regex ]]; then
               lock_pid="''${BASH_REMATCH[1]}"
             fi
-            if [[ -z "$lock_pid" ]] || ! kill -0 "$lock_pid" 2>/dev/null; then
+            # /proc/<pid> liveness (Linux-only) avoids kill -0's EPERM misfire
+            # if the unit ever runs non-root. --max-lock is the real expiry.
+            if [[ -z "$lock_pid" ]] || [[ ! -d "/proc/$lock_pid" ]]; then
               echo "Clearing orphaned bisync lock for ${name} (holder PID ''${lock_pid:-unknown} not running): $lock_file" >&2
               ${pkgs.coreutils}/bin/rm -f "$lock_file"
               cleared_lock=true

--- a/modules/nixos/r2-sync.nix
+++ b/modules/nixos/r2-sync.nix
@@ -130,6 +130,13 @@ let
       remoteTrashArg = lib.escapeShellArg remoteTrashPath;
       remoteCheckPath = ":s3:${layout.path}/${checkFilename}";
       remoteCheckArg = lib.escapeShellArg remoteCheckPath;
+      # rclone bisync records this expiry in each run's lock file and renews it
+      # while the run is alive, so a lock orphaned by a crash or shutdown is
+      # auto-overridden by the next run once it lapses. Empty string omits the
+      # flag (rclone default: locks never expire, wedging the service forever).
+      maxLockArg = lib.optionalString (
+        mount.bisync.maxLock != ""
+      ) "--max-lock=${lib.escapeShellArg mount.bisync.maxLock}";
       bisyncScript = pkgs.writeShellScript "r2-bisync-${name}" ''
         set -euo pipefail
         ${resolveAccountIdShell}
@@ -166,6 +173,9 @@ let
             --backup-dir1=${localTrashArg} \
             --backup-dir2=${remoteTrashArg} \
             --max-delete=${toString mount.bisync.maxDelete} \
+            ${maxLockArg} \
+            --recover \
+            --resilient \
             --workdir=${workdirArg} \
             --check-access \
             --check-filename=${checkFilenameArg} \
@@ -183,6 +193,36 @@ let
         fi
 
         printf '%s\n' "$bisync_output" >&2
+
+        # A lock file left by a run that was killed (host shutdown, OOM, crash)
+        # blocks every later run with "prior lock file found". The bisync workdir
+        # is host-local and single-writer, so a lock whose recorded holder PID is
+        # no longer running is a safe orphan to clear, then retry once. --max-lock
+        # auto-expires orphans written after it was set; this branch also recovers
+        # locks written before it, whose stored expiry is far in the future.
+        if [[ "$bisync_output" == *"prior lock file found"* ]]; then
+          cleared_lock=false
+          for lock_file in ${workdirArg}/*.lck; do
+            [[ -f "$lock_file" ]] || continue
+            lock_pid=""
+            lock_content="$(< "$lock_file")" || true
+            if [[ "$lock_content" =~ \"PID\":\"([0-9]+)\" ]]; then
+              lock_pid="''${BASH_REMATCH[1]}"
+            fi
+            if [[ -z "$lock_pid" ]] || ! kill -0 "$lock_pid" 2>/dev/null; then
+              echo "Clearing orphaned bisync lock for ${name} (holder PID ''${lock_pid:-unknown} not running): $lock_file" >&2
+              ${pkgs.coreutils}/bin/rm -f "$lock_file"
+              cleared_lock=true
+            else
+              echo "Bisync lock for ${name} held by live PID $lock_pid; leaving it in place." >&2
+            fi
+          done
+          if [[ "$cleared_lock" == true ]]; then
+            echo "Retrying bisync for ${name} after clearing orphaned lock." >&2
+            run_bisync "''${resync_flags[@]}"
+            exit 0
+          fi
+        fi
 
         # When a mount path or remote basename changes, old listing files may still
         # exist in workdir and bisync asks for manual --resync recovery.
@@ -358,6 +398,21 @@ in
                 ];
                 default = "path1";
                 description = "Resync preference used automatically on first run (when bisync state is missing).";
+              };
+
+              maxLock = lib.mkOption {
+                type = lib.types.str;
+                default = "15m";
+                example = "5m";
+                description = ''
+                  Lock-file expiry passed to rclone bisync as --max-lock. rclone
+                  renews the lock while a run is alive, so a run orphaned by a
+                  crash or shutdown is auto-overridden by the next run once this
+                  expiry lapses. The empty string omits --max-lock, restoring
+                  rclone's default where locks never expire and an orphaned lock
+                  wedges the service until cleared by hand. rclone enforces a 2m
+                  minimum when the flag is set.
+                '';
               };
             };
           };


### PR DESCRIPTION
## Summary

`rclone bisync`'s `--max-lock` defaults to `0` (never expire) and the generated
`r2-bisync-<name>.service` never passed it. When a run is interrupted (host
shutdown, OOM, crash) rclone leaves a lock file whose stored `TimeExpires` is
written roughly 200 years in the future, so `lockFileIsExpired()` never fires
and every subsequent run aborts with `prior lock file found`. The `oneshot`
then fails on every timer tick until the lock is deleted by hand.

Observed on a consumer host: the `docs` mount was wedged for 10 days and the
`fonts` mount for 5 months. Because the bisync timer fires on a short interval,
a failing tick landing inside a `nixos-rebuild` activation window surfaced as an
activation failure (exit 4).

Changes:

- Add `mounts.<name>.bisync.maxLock` (default `15m`) and thread it as
  `--max-lock`, so a run orphaned by a crash self-expires and the next run can
  take over. rclone renews the lock while a run is alive, so long legitimate
  runs are unaffected.
- Add `--recover` and `--resilient` so an interrupted run recovers on the next
  run instead of requiring a manual `--resync`.
- On `prior lock file found` (only when `--max-lock` is enabled), clear a lock
  whose recorded holder PID is no longer running (the bisync workdir is
  host-local and single-writer), then retry once. This also recovers locks
  written before `--max-lock` existed, whose far-future stored expiry rclone
  still honors. A lock held by a live PID is left untouched; liveness is checked
  via `/proc/<pid>` and the PID is parsed with a quote/whitespace-tolerant regex.
- Extend the `nixos-module-eval` check to require `--max-lock=` in the generated
  bisync unit so the flag cannot silently regress (the bare `--max-lock` string
  also appears in a script comment, so the `=` pins the match to the real flag).

Empty `maxLock` fully opts out: it omits `--max-lock` and disables the
orphan-lock cleanup, restoring rclone's native behavior where a stuck lock
blocks later runs until removed by hand.

## Test plan

- `nix fmt`: clean.
- `statix check` and `deadnix --fail` on changed files: clean.
- `nix build .#checks.x86_64-linux.nixos-module-eval`: passes; the check greps
  the built bisync unit for `--max-lock=`.
- Inspected the generated `r2-bisync-documents` ExecStart: carries
  `--max-lock=15m`, `--recover`, `--resilient`, and the orphan-lock recovery
  block (`prior lock file found` guard, `/proc/<pid>` liveness gate, retry);
  `bash -n` clean.
- Built the unit with `maxLock = ""`: no `--max-lock=` flag and the cleanup gate
  renders `[[ -n "" ]]` (disabled); `bash -n` clean.
- Verified against pinned rclone 1.74.3 `cmd/bisync/lockfile.go`: `PID` is a
  Go `string` (`strconv.Itoa`) encoded compact via `json.NewEncoder` as
  `"PID":"12345"`, which the PID regex matches.
- Operationally validated the underlying failure on the consumer host: after
  clearing the stale locks the docs bisync recovered and resumed syncing; this
  change prevents the wedge from recurring.